### PR TITLE
Fix many pod2man errors

### DIFF
--- a/lib/Net/Google/SafeBrowsing2.pm
+++ b/lib/Net/Google/SafeBrowsing2.pm
@@ -133,6 +133,8 @@ use constant {
 
 =over 4
 
+=back
+
 =head2 new()
 
 Create a Net::Google::SafeBrowsing2 object
@@ -181,8 +183,6 @@ Optional. Google Safe Browsing version. 2.2 by default
 
 =back
 
-=back
-
 =cut
 
 sub new {
@@ -216,6 +216,8 @@ sub new {
 =head1 PUBLIC FUNCTIONS
 
 =over 4
+
+=back
 
 =head2 update()
 
@@ -609,13 +611,13 @@ sub last_error {
 
 =pod
 
-=back
-
 =head1 PRIVATE FUNCTIONS
 
 These functions are not intended to be used externally.
 
 =over 4
+
+=back
 
 =head2 lookup_suffix()
 
@@ -1725,8 +1727,6 @@ sub expand_range {
 	return @list;
 }
 
-
-=back
 
 =head1 CHANGELOG
 

--- a/lib/Net/Google/SafeBrowsing2/DBI.pm
+++ b/lib/Net/Google/SafeBrowsing2/DBI.pm
@@ -36,6 +36,8 @@ This is a base implementation of L<Net::Google::SafeBrowsing2::Storage> using DB
 
 =over 4
 
+=back
+
 =head2 new()
 
 This method should be overwritten.
@@ -47,8 +49,6 @@ Arguments
 =item keep_all
 
 Optional. Set to 1 to keep old information (such as expiring full hashes) in the database. 0 (delete) by default.
-
-=back
 
 
 =back
@@ -76,6 +76,8 @@ sub new {
 =over 4
 
 See L<Net::Google::SafeBrowsing2::Storage> for a complete list of public functions.
+
+=back
 
 =head2 close()
 
@@ -239,10 +241,6 @@ sub export {
 
 	CORE::close(EXPORT);
 }
-
-=back
-
-=cut
 
 sub init {
 	my ($self, %args) = @_;

--- a/lib/Net/Google/SafeBrowsing2/Lookup.pm
+++ b/lib/Net/Google/SafeBrowsing2/Lookup.pm
@@ -45,6 +45,8 @@ The source code is available on github at L<https://github.com/juliensobrier/Net
 
 =over 4
 
+=back
+
 =head2 new()
 
 Create a Net::Google::SafeBrowsing2::Lookup object
@@ -82,8 +84,6 @@ Optional. Delay, in seconds, between 2 requests to the Google server. See the C<
 
 =back
 
-=back
-
 =cut
 
 sub new {
@@ -108,6 +108,8 @@ sub new {
 =head1 PUBLIC FUNCTIONS
 
 =over 4
+
+=back
 
 =head2 lookup()
 
@@ -366,8 +368,6 @@ sub canonical_uri {
 	return URI->new($escape);
 }
 
-
-=back
 
 =head1 CHANGELOG
 

--- a/lib/Net/Google/SafeBrowsing2/MySQL.pm
+++ b/lib/Net/Google/SafeBrowsing2/MySQL.pm
@@ -36,6 +36,8 @@ This is an implementation of L<Net::Google::SafeBrowsing2::Storage> using MySQL.
 
 =over 4
 
+=back
+
 =head2 new()
 
 Create a Net::Google::SafeBrowsing2::MySQL object
@@ -78,8 +80,6 @@ Optional. Set to 1 to keep old information (such as expiring full hashes) in the
 =back
 
 
-=back
-
 =cut
 
 sub new {
@@ -108,14 +108,14 @@ sub new {
 
 See L<Net::Google::SafeBrowsing2::Storage> for a complete list of public functions.
 
+=back
+
 =head2 close()
 
 Cleanup old full hashes, and close the connection to the database.
 
   $storage->close();
 
-
-=back
 
 =cut
 

--- a/lib/Net/Google/SafeBrowsing2/Postgres.pm
+++ b/lib/Net/Google/SafeBrowsing2/Postgres.pm
@@ -40,6 +40,8 @@ Postgres.
 
 =over 4
 
+=back
+
 =head2 new()
 
 Create a Net::Google::SafeBrowsing2::Postgres object
@@ -78,8 +80,6 @@ in the database. 0 (delete) by default.
 
 =back
 
-=back
-
 =cut
 
 sub new {
@@ -115,13 +115,13 @@ sub new {
 
 See L<Net::Google::SafeBrowsing2::Storage> for a complete list of public functions.
 
+=back
+
 =head2 close()
 
 Cleanup old full hashes, and close the connection to the database.
 
   $storage->close();
-
-=back
 
 =cut
 

--- a/lib/Net/Google/SafeBrowsing2/Sqlite.pm
+++ b/lib/Net/Google/SafeBrowsing2/Sqlite.pm
@@ -36,6 +36,8 @@ This is an implementation of L<Net::Google::SafeBrowsing2::Storage> using Sqlite
 
 =over 4
 
+=back
+
 =head2 new()
 
 Create a Net::Google::SafeBrowsing2::Sqlite object
@@ -60,8 +62,6 @@ Sqlite cache size. 20000 by default.
 
 =back
 
-
-=back
 
 =cut
 
@@ -90,14 +90,13 @@ sub new {
 
 See L<Net::Google::SafeBrowsing2::Storage> for a complete list of public functions.
 
+=back
+
 =head2 close()
 
 Cleanup old full hashes, and close the connection to the database.
 
   $storage->close();
-
-
-=back
 
 =cut
 

--- a/lib/Net/Google/SafeBrowsing2/Storage.pm
+++ b/lib/Net/Google/SafeBrowsing2/Storage.pm
@@ -32,14 +32,13 @@ This module cannot be used on its own as it does not actually store anything. Al
 
 =over 4
 
+=back
+
 =head2 new()
 
   Create a Net::Google::SafeBrowsing2::Storage object
 
   my $storage	=> Net::Google::SafeBrowsing2::Storage->new();
-
-
-=back
 
 =cut
 
@@ -57,6 +56,8 @@ sub new {
 =head1 PUBLIC FUNCTIONS
 
 =over 4
+
+=back
 
 =head2 add_chunks()
 
@@ -889,13 +890,13 @@ sub reset {
 }
 
 
-=back
-
 =head1 PRIVATE FUNCTIONS
 
 These functions are not intended for debugging purpose.
 
 =over 4
+
+=back
 
 =head2 hex_to_ascii()
 
@@ -936,8 +937,6 @@ sub ascii_to_hex {
 
 	return $hex;
 }
-
-=back
 
 =head1 CHANGELOG
 


### PR DESCRIPTION
Julien,

Thank you for your excellent work regarding Google Safe Browsing API.

In the process of packaging Net::Google::SafeBrowsing2 for Debian and uploading it into the official distribution, I saw the following pod2man errors and had to fix them:

Now running lintian...
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2.3pm.gz:505
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::DBI.3pm.gz:226
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::Lookup.3pm.gz:236
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::MySQL.3pm.gz:223
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::Postgres.3pm.gz:210
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::Sqlite.3pm.gz:221
W: libnet-google-safebrowsing2-perl: manpage-has-errors-from-pod2man usr/share/man/man3/Net::Google::SafeBrowsing2::Storage.3pm.gz:660
Finished running lintian.

This patch fixes those errors.

Can you please pull this branch?

Regards,

PS: by the way, I opened an issue on the Python version that prevent me from uploading it into the official Debian distribution
